### PR TITLE
feat: configurable OpenAI model and structured suggestions

### DIFF
--- a/components/TheChatGptAnalyzer.vue
+++ b/components/TheChatGptAnalyzer.vue
@@ -7,7 +7,9 @@
                     <span class="loading loading-bars loading-lg justify-self-center"></span>
                 </div>
                 <div v-if="analyzed && !isAnalyzing" class="whitespace-pre-wrap w-fit">
-                    <div class="prose max-w-none" v-html="analysis"></div>
+                    <ul class="prose max-w-none list-disc pl-5 space-y-2">
+                        <li v-for="(suggestion, index) in suggestions" :key="index">{{ suggestion }}</li>
+                    </ul>
                 </div>
                 <div class="mx-auto justify-items-center md:col-span-2 py-2 hover:cursor-pointer" v-if="isError">
                     <div class="alert alert-error" @click="confirmError">
@@ -33,7 +35,7 @@
 const isAnalyzing = ref(false);
 const isError = ref(false);
 const analyzed = ref(false);
-const analysis = ref("")
+const suggestions = ref<string[]>([])
 const skillStore = useSkillsStore();
 
 const allscanned = computed(() => {
@@ -63,7 +65,7 @@ const analyzeWithChatGptGet = async () => {
 
     if (data && !isError.value) {
         console.log(data.value);
-        analysis.value = String(data.value!);
+        suggestions.value = (data.value as any).suggestions || [];
         isAnalyzing.value = false;
         analyzed.value = true;
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {// availabe only server side
     openAIKey: process.env.OPENAIKEY,
+    openAIModel: process.env.OPENAI_MODEL || 'gpt-4.1-mini',
     mongoURI: process.env.MONGOURI,
     BASE_URL: process.env.BASE_URL || 'http://localhost:3000',
     // Public keys that are exposed to the client

--- a/server/api/analyzewithchatgpt.get.ts
+++ b/server/api/analyzewithchatgpt.get.ts
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event) => {
     query.resume +
     " THIS IS THE END OF THE RESUME \n\n Here is the job description that I am interested in: " +
     query.jobdescription +
-    " END OF JOB DESCRIPTION \n\n As a master career consultant, please review and provide some practical feedback on what changes I could make to my resume to have a greater chance of getting an interview, please consider the job description and provide pragmatic suggestions. Please format your response in basic html that will display using v-html in a vue template - do not surround response with ```html - just basic html please.";
+    " END OF JOB DESCRIPTION \n\n As a master career consultant, please review and provide some practical feedback on what changes I could make to my resume to have a greater chance of getting an interview, please consider the job description and provide pragmatic suggestions. Return your recommendations as a JSON object with a `suggestions` array of strings.";
 
   console.log("To Chat GPT:" + question);
 
@@ -29,14 +29,31 @@ export default defineEventHandler(async (event) => {
 
   const openai = new OpenAI(configuration);
   try {
-    const chatCompletion = await openai.chat.completions.create({
-      messages: [{ role: "user", content: question }],
-      model: "gpt-4.1-mini",
+    const response = await openai.responses.create({
+      model: config.openAIModel,
+      input: question,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "resume_suggestions",
+          schema: {
+            type: "object",
+            properties: {
+              suggestions: {
+                type: "array",
+                items: { type: "string" },
+                description: "Practical resume improvement suggestions",
+              },
+            },
+            required: ["suggestions"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
     });
 
-    console.log(chatCompletion.choices[0].toString);
-
-    return chatCompletion.choices[0].message?.content;
+    return JSON.parse(response.output_text);
   } catch (error: any) {
     if (error.response) {
       console.log(error.response.status);

--- a/server/api/analyzewithchatgpt.get.ts
+++ b/server/api/analyzewithchatgpt.get.ts
@@ -32,9 +32,9 @@ export default defineEventHandler(async (event) => {
     const response = await openai.responses.create({
       model: config.openAIModel,
       input: question,
-      response_format: {
-        type: "json_schema",
-        json_schema: {
+      text: {
+        format: {
+          type: "json_schema",
           name: "resume_suggestions",
           schema: {
             type: "object",


### PR DESCRIPTION
## Summary
- allow setting OpenAI model via `OPENAI_MODEL`
- return structured suggestion arrays from `analyzewithchatgpt` API
- show AI suggestions as bulleted list in analyzer component

## Testing
- `npm test` *(tests skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_6895bf66aeec8325aaa356027dd02739